### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request-verification.yml
+++ b/.github/workflows/pull-request-verification.yml
@@ -117,6 +117,8 @@ jobs:
 
   test-change-type:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
     - name: configure GIT user


### PR DESCRIPTION
Potential fix for [https://github.com/Ludy87/paths-filter/security/code-scanning/15](https://github.com/Ludy87/paths-filter/security/code-scanning/15)

To fix the problem, we need to add an explicit `permissions` block to the `test-change-type` job in the `.github/workflows/pull-request-verification.yml` file. The minimal recommended permission is `contents: read`, which allows the job to read repository contents but not write to them. This change should be made directly under the `runs-on: ubuntu-latest` line for the `test-change-type` job (line 119), following the pattern used in the `test-external` job. No additional imports or definitions are required; this is a YAML configuration change only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
