### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request-verification.yml
+++ b/.github/workflows/pull-request-verification.yml
@@ -97,6 +97,8 @@ jobs:
 
   test-local-changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
     - run: echo "NEW FILE" > local


### PR DESCRIPTION
Potential fix for [https://github.com/Ludy87/paths-filter/security/code-scanning/14](https://github.com/Ludy87/paths-filter/security/code-scanning/14)

To fix the problem, we should add a `permissions` block to the `test-local-changes` job, specifying the least privilege required. Since this job only checks local file changes and does not appear to need write access to the repository or pull requests, the minimal permission of `contents: read` is appropriate. This change should be made by adding the following block under the `test-local-changes` job, at the same indentation level as `runs-on`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed, as this is a configuration change in the workflow YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
