### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: "Build"
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Ludy87/paths-filter/security/code-scanning/11](https://github.com/Ludy87/paths-filter/security/code-scanning/11)

To fix the problem, we should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. Since both jobs (`build` and `self-test`) only need to read repository contents (for actions/checkout and setup-node), the best fix is to add `permissions: contents: read` at the workflow level, just below the `name` field and before the `on` field. This will apply the least privilege to all jobs in the workflow unless overridden. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
