### PR TITLE
feat: add newline export format

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ For more scenarios see [examples](#examples) section.
 - New major release `v3` after update to Node 20 [Breaking change]
 - Add `ref` input parameter
 - Add `list-files: csv` format
+- Add `list-files: lines` format
 - Configure matrix job to run for each folder with changes using `changes` output
 - Improved listing of matching files with `list-files: shell` and `list-files: escape` options
 - Paths expressions are now evaluated using [picomatch](https://github.com/micromatch/picomatch) library
@@ -141,6 +142,7 @@ For more information, see [CHANGELOG](https://github.com/dorny/paths-filter/blob
     #             If needed, it uses single or double quotes to wrap filename with unsafe characters.
     #   'escape'- Space delimited list usable as command-line argument list in Linux shell.
     #             Backslash escapes every potentially unsafe character.
+    #   'lines' - Newline delimited list of files without any escaping.
     # Default: none
     list-files: ''
 

--- a/__tests__/export-format.test.ts
+++ b/__tests__/export-format.test.ts
@@ -39,4 +39,9 @@ describe('exportResults file listing formats', () => {
     exportResults(results, 'escape')
     expect(core.setOutput).toHaveBeenCalledWith('sample_files', 'simple.txt file\\ with\\ space.txt')
   })
+
+  test('exports newline separated list', () => {
+    exportResults(results, 'lines')
+    expect(core.setOutput).toHaveBeenCalledWith('sample_files', 'simple.txt\nfile with space.txt')
+  })
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ import * as git from './git'
 import {backslashEscape, shellEscape} from './list-format/shell-escape'
 import {csvEscape} from './list-format/csv-escape'
 
-type ExportFormat = 'none' | 'csv' | 'json' | 'shell' | 'escape'
+type ExportFormat = 'none' | 'csv' | 'json' | 'shell' | 'escape' | 'lines'
 
 async function run(): Promise<void> {
   try {
@@ -288,13 +288,15 @@ function serializeExport(files: File[], format: ExportFormat): string {
       return fileNames.map(backslashEscape).join(' ')
     case 'shell':
       return fileNames.map(shellEscape).join(' ')
+    case 'lines':
+      return fileNames.join('\n')
     default:
       return ''
   }
 }
 
 function isExportFormat(value: string): value is ExportFormat {
-  return ['none', 'csv', 'shell', 'json', 'escape'].includes(value)
+  return ['none', 'csv', 'shell', 'json', 'escape', 'lines'].includes(value)
 }
 
 function getErrorMessage(error: unknown): string {


### PR DESCRIPTION
## Summary
- allow exporting lists of changed files separated by newlines
- document and test new `list-files: lines` option

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4b216f9b0832588de48fc02dc02a7