### PR TITLE
Fix all_changed output logic in exportResults

### DIFF
--- a/__tests__/outputs.test.ts
+++ b/__tests__/outputs.test.ts
@@ -40,7 +40,7 @@ describe('all_changed and any_changed outputs', () => {
       docs: []
     }
     exportResults(results, 'none')
-    expect(core.setOutput).toHaveBeenCalledWith('all_changed', true)
+    expect(core.setOutput).toHaveBeenCalledWith('all_changed', false)
     expect(core.setOutput).toHaveBeenCalledWith('any_changed', false)
   })
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -238,9 +238,13 @@ export function exportResults(results: FilterResults, format: ExportFormat): voi
   core.info('Results:')
   const changes: string[] = []
   let anyChanged = false
-  let hasUnchangedFilter = false
+  const resultsObjLength = Object.keys(results).length
+  let counter = 0
   for (const [key, files] of Object.entries(results)) {
     const value = files.length > 0
+    if (value) {
+      counter++
+    }
     core.startGroup(`Filter ${key} = ${value}`)
     if (files.length > 0) {
       changes.push(key)
@@ -251,7 +255,6 @@ export function exportResults(results: FilterResults, format: ExportFormat): voi
       }
     } else {
       core.info('Matching files: none')
-      hasUnchangedFilter = true
     }
 
     core.setOutput(key, value)
@@ -263,7 +266,7 @@ export function exportResults(results: FilterResults, format: ExportFormat): voi
     core.endGroup()
   }
 
-  const allChanged = anyChanged ? !hasUnchangedFilter : true
+  const allChanged = resultsObjLength === counter ? true : false
   core.setOutput('all_changed', allChanged)
   core.setOutput('any_changed', anyChanged)
 


### PR DESCRIPTION
Corrects the calculation of the 'all_changed' output to ensure it is only true when all filters have matching files. Updates related test to expect the correct output value.