### PR TITLE
chore: translate German test comments

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -16,7 +16,7 @@ jest.mock('@actions/github', () => ({
 
 describe('getChangedFilesFromApi', () => {
   test('handles copied status', async () => {
-    // GitHub liefert bei "copied": filename = Ziel, previous_filename = Quelle
+    // For "copied", GitHub sets filename to the destination and previous_filename to the source
     const mockResponse = {
       status: 200,
       data: [
@@ -45,7 +45,7 @@ describe('getChangedFilesFromApi', () => {
 
     const files = await getChangedFilesFromApi('token', pr)
 
-    // Erwartung: "from" ist gesetzt
+    // Expect "from" to be set
     expect(files).toEqual([
       {filename: 'src/file1.ts', status: ChangeStatus.Copied, from: 'src/file.ts', to: 'src/file1.ts'}
     ])
@@ -70,8 +70,8 @@ describe('getChangedFilesFromApi', () => {
 
     const files = await getChangedFilesFromApi('token', {number: 7} as any)
 
-    // Wie gehabt: rename → Added (neu) + Deleted (alt)
-    // Neu: copied behält "from"
+    // Renamed files return a single entry with both source and destination
+    // Copied files retain their source path in "from"
     expect(files).toEqual([
       {filename: 'deleted.txt', status: ChangeStatus.Deleted, from: 'deleted.txt'},
       {filename: 'new.txt', status: ChangeStatus.Renamed, from: 'old.txt', to: 'new.txt'},

--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -35,16 +35,16 @@ describe('parsing output of the git diff command', () => {
 
     const files = git.parseGitDiffOutput(payload)
 
-    // Prüfe per Subset-Match die wesentlichen Felder
+    // Check essential fields using subset match
     expect(files).toMatchObject([
       {filename: 'src/c/copied75.ts', status: ChangeStatus.Copied, from: 'src/copied75.ts', similarity: 75},
       {filename: 'src/renamed100.ts', status: ChangeStatus.Renamed, from: 'src/renamed100_old.ts', similarity: 100},
       {filename: 'src/conflict.ts', status: ChangeStatus.Unmerged},
-      {filename: 'src/c/copied.ts', status: ChangeStatus.Copied, from: 'src/copied.ts'}, // ohne Score
-      {filename: 'src/renamed.ts', status: ChangeStatus.Renamed, from: 'src/renamed_old.ts'} // ohne Score
+      {filename: 'src/c/copied.ts', status: ChangeStatus.Copied, from: 'src/copied.ts'}, // no score
+      {filename: 'src/renamed.ts', status: ChangeStatus.Renamed, from: 'src/renamed_old.ts'} // no score
     ])
 
-    // Optional: explizit sicherstellen, dass bei Einträgen ohne Zahl kein similarity-Field gesetzt ist
+    // Optionally ensure entries without a similarity score omit the similarity field
     expect(files[3].similarity).toBeUndefined()
     expect(files[4].similarity).toBeUndefined()
   })


### PR DESCRIPTION
## Summary
- translate remaining German comments in tests to English
- clarify rename and copy behavior in API tests
- document similarity handling in git diff parsing tests

## Testing
- `npm test`
- `npm run format-check`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5f952b56c8325aeb606a83673022c