### PR TITLE
Fix typos in action metadata

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,16 +27,16 @@ inputs:
     description: |
       Enables listing of files matching the filter:
         'none'  - Disables listing of matching files (default).
-        'csv'   - Coma separated list of filenames.
+        'csv'   - Comma separated list of filenames.
                   If needed it uses double quotes to wrap filename with unsafe characters.
         'json'  - Serialized as JSON array.
         'shell' - Space delimited list usable as command line argument list in linux shell.
                   If needed it uses single or double quotes to wrap filename with unsafe characters.
-        'escape'- Space delimited list usable as command line argument list in linux shell.
+        'escape' - Space delimited list usable as command line argument list in linux shell.
                   Backslash escapes every potentially unsafe character.
         'lines' - Newline delimited list of files without any escaping.
     required: false
-    default: none
+    default: 'none'
   initial-fetch-depth:
     description: |
       How many commits are initially fetched from base branch.


### PR DESCRIPTION
## Summary
- fix spelling in the `list-files` option documentation
- clarify the escape option formatting and ensure the default is quoted as a string

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e169e5a5248325adeb5e0bc23c121e